### PR TITLE
Widget: replace `stats_extra` call with action

### DIFF
--- a/podcasting/widget.php
+++ b/podcasting/widget.php
@@ -69,7 +69,7 @@ class Podcast_Widget extends WP_Widget {
 		echo '<p><a href="' . $subscribe_url . '">Subscribe via iTunes</a></p>';
 
 		echo $args['after_widget'];
-		stats_extra( 'widget_view', 'podcasting' );
+		do_action( 'jetpack_stats_extra', 'widget_view', 'podcasting' );
 	}
 
 	function form( $instance ) {


### PR DESCRIPTION
This PR removes a call to `stats_extra`, which is not defined in `wpcomsh`, and replaces it with the `jetpack_stats_extra` action. Fixes #2.

**To test:**
* Setup `wpcomsh` on a .org installation following the instructions in the [`README`](https://github.com/Automattic/wpcomsh#development).
* Edit `composer.json` within `wpcomsh` to change the version number for `automattic/at-pressable-podcasting` from `1.1.0` to `dev-fix/widget-stats-extra`.
* `composer update`
* Enabled podcasting by selecting a category
* Add the podcasting widget to your site
* Verify that when viewing the widget, you see no fatals in your error log
* Switch to a theme that supports media headers (such as Twenty Seventeen)
* Verify that you're able to set a video header under "Header Media" in the Customizer