### PR TITLE
Sync D12239: Display email option in feed, if set

### DIFF
--- a/podcasting/customize-feed.php
+++ b/podcasting/customize-feed.php
@@ -48,6 +48,12 @@ function podcasting_feed_head() {
 		echo '<itunes:author>' . esc_html( strip_tags( $author ) ) . "</itunes:author>\n";
 	}
 
+	$email = get_option( 'podcasting_email' );
+
+	if ( ! empty( $email ) ) {
+		echo '<itunes:email>' . esc_html( strip_tags ( $email ) ) . "</itunes:email>\n";
+	}
+
 	$copyright = get_option( 'podcasting_copyright' );
 
 	if ( !empty( $copyright ) ) {


### PR DESCRIPTION
This adds email to the podcasting feed. Test-plan and code reviewed via D12239-code.