### PR TITLE
Sync D12286: REST API: Allow podcasting settings to be changed

### DIFF
--- a/podcasting.php
+++ b/podcasting.php
@@ -16,6 +16,8 @@ class Automattic_Podcasting {
 			require_once plugin_dir_path( __FILE__ ) . 'podcasting/settings.php';
 		}
 
+		require_once plugin_dir_path( __FILE__ ) . 'podcasting/settings-rest-api.php';
+
 		if ( self::podcasting_is_enabled() ) {
 			add_action( 'after_setup_theme', array( 'Automattic_Podcasting', 'podcasting_add_post_thumbnail_support' ), 20 ); // Later then themes normally do.
 			remove_action( 'rss2_head', 'rss2_blavatar' );

--- a/podcasting/settings-rest-api.php
+++ b/podcasting/settings-rest-api.php
@@ -1,0 +1,58 @@
+<?php
+class Automattic_Podcasting_Settings_REST_API {
+	public static function handle_get( $settings ) {
+		$settings['podcasting_category_id']  = (int) Automattic_Podcasting::podcasting_get_podcasting_category_id();
+		$settings['podcasting_title']        = (string) get_option( 'podcasting_title', '' );
+		$settings['podcasting_subtitle']     = (string) get_option( 'podcasting_subtitle', '' );
+		$settings['podcasting_talent_name']  = (string) get_option( 'podcasting_talent_name', '' );
+		$settings['podcasting_summary']      = (string) get_option( 'podcasting_summary', '' );
+		$settings['podcasting_copyright']    = (string) get_option( 'podcasting_copyright', '' );
+		$settings['podcasting_explicit']     = (string) get_option( 'podcasting_explicit', 'no' );
+		$settings['podcasting_image']        = (string) get_option( 'podcasting_image', '' );
+		$settings['podcasting_keywords']     = (string) get_option( 'podcasting_keywords', '' );
+		$settings['podcasting_category_1']   = (string) get_option( 'podcasting_category_1', '' );
+		$settings['podcasting_category_2']   = (string) get_option( 'podcasting_category_2', '' );
+		$settings['podcasting_category_3']   = (string) get_option( 'podcasting_category_3', '' );
+		$settings['podcasting_email']        = (string) get_option( 'podcasting_email', '' );
+
+		return $settings;
+	}
+
+	public static function filter_input_for_update( $original_input, $unfiltered_input ) {
+		$output = (array) $original_input;
+
+		$cast_map = array(
+			'podcasting_category_id' => 'int',
+			'podcasting_title'       => 'string',
+			'podcasting_subtitle'    => 'string',
+			'podcasting_talent_name' => 'string',
+			'podcasting_summary'     => 'string',
+			'podcasting_copyright'   => 'string',
+			'podcasting_explicit'    => 'string',
+			'podcasting_image'       => 'string',
+			'podcasting_keywords'    => 'string',
+			'podcasting_category_1'  => 'string',
+			'podcasting_category_2'  => 'string',
+			'podcasting_category_3'  => 'string',
+			'podcasting_email'       => 'string',
+		);
+		
+		foreach( $cast_map as $key => $type ) {
+			if ( isset( $unfiltered_input[ $key ] ) ) {
+				switch ( $type ) {
+					case 'int':
+						$output[ $key ] = (int) $unfiltered_input[ $key ];
+						break;
+					case 'string':
+						$output[ $key ] = (string) $unfiltered_input[ $key ];
+						break;
+				}
+			}
+		}
+
+		return $output;
+	}
+}
+
+add_filter( 'site_settings_endpoint_get', array( 'Automattic_Podcasting_Settings_REST_API', 'handle_get' ) );
+add_filter( 'rest_api_update_site_settings', array( 'Automattic_Podcasting_Settings_REST_API', 'filter_input_for_update' ), 10, 2 );


### PR DESCRIPTION
This PR partially syncs D12286-code. The change allows podcasting settings to be changed via the settings endpoint.

Note: This does _NOT_ sync the change to `class.wpcom-json-api-site-settings-endpoint.php` which add a second parameter to the `rest_api_update_site_settings` filter. This change will be synced to Jetpack separately.

**To test:**
* [x] Setup `wpcomsh` on a .org installation following the instructions in the [`README`](https://github.com/Automattic/wpcomsh#development).
* [x] Edit `composer.json` within `wpcomsh` to change the version number for `automattic/at-pressable-podcasting` from `1.1.0` to `dev-sync/D12286`.
* [x] `composer update`
* [x] Patch Jetpack on your .org test site to include the change to the `rest_api_update_site_settings` filter from D12286-code / https://github.com/Automattic/jetpack/pull/9464.
* [x] Verify that you're able to enable and update podcasting settings from within Calypso for your sandboxed site.
* [x] Make sure things gracefully fail when Jetpack isn't patched. _(Settings screens load with no errors, but podcasting settings are not successfully updated.  This is as expected and should never be seen in production.)_