### PR TITLE
Sync D14335: Podcasting: stop forcing enclosure URLs to http 

### DIFF
--- a/podcasting/customize-feed.php
+++ b/podcasting/customize-feed.php
@@ -139,8 +139,6 @@ function podcasting_feed_item() {
 			if ( is_array( $image ) ) {
 				$image = $image[0];
 			}
-			// iTunes barfs on https images, so force http here.
-			$image = str_replace( 'https://', 'http://', $image );
 			echo "<itunes:image href='" . esc_url( $image ) . "' />\n";
 		}
 	}
@@ -164,7 +162,7 @@ function podcasting_feed_item() {
 	echo "<itunes:subtitle>" . esc_html( $subtitle ) . "</itunes:subtitle>\n";
 
 	if ( ! empty( $post_meta['enclosure'] ) ) {
-		echo "<enclosure url='" . esc_url( str_replace( 'https://', 'http://', $post_meta['enclosure']['url'] ) ) . "' length='" . esc_html( $post_meta['enclosure']['length'] ) . "' type='" . esc_html( $post_meta['enclosure']['mime'] ) . "' />\n";
+		echo "<enclosure url='" . esc_url( $post_meta['enclosure']['url'] ) . "' length='" . esc_html( $post_meta['enclosure']['length'] ) . "' type='" . esc_html( $post_meta['enclosure']['mime'] ) . "' />\n";
 	}
 
 	// TODO <itunes:duration>7:10</itunes:duration>; iTunes seems to figure this out on it's own. Would be nice to have in the future


### PR DESCRIPTION
This PR syncs the relevant parts of D14335-code. Since `podcasting/customize-feed.php` is the only file from that Diff to be synced to `wpcomsh`, it is the only file updated.

**Testing instructions**
* Setup `wpcomsh` on a .org installation following the instructions in the [`README`](https://github.com/Automattic/wpcomsh#development).
* Edit `composer.json` within `wpcomsh` to change the version number for `automattic/at-pressable-podcasting` from its existing value to `dev-sync/D14335`.
* `composer update`
* Enable podcasting if it isn't already by visiting Media Options in wp-admin and selecting a category. (Note: if you've managed podcasting from Calypso, you should use that instead).
* Specify a cover image that is HTTPs.
* Create a new post in the podcast category and attach media that is https.
* Verify that the feed contains your media with the an https url.
* Verify that the cover image remains https (even non-https images should become https because they are run through Photon w/ the protocol forced to https).