### PR TITLE
Sync D14334: Podcasting: use post details as primary episode details

### DIFF
--- a/podcasting/customize-feed.php
+++ b/podcasting/customize-feed.php
@@ -23,7 +23,7 @@ add_filter( 'wp_title_rss', 'podcasting_bloginfo_rss_name' );
 
 function podcasting_feed_head() {
 	$subtitle = get_option( 'podcasting_subtitle' );
-	
+
 	if ( empty( $subtitle ) ) {
 		$subtitle = get_bloginfo( 'description' );
 	}
@@ -114,9 +114,9 @@ function podcasting_feed_item() {
 
 	$post_meta = get_post_meta( $post->ID, 'podcast_episode', true );
 
-	$author = get_option( 'podcasting_talent_name' );
+	$author = get_the_author();
 	if ( empty( $author ) ) {
-		$author = get_the_author();
+		$author = get_option( 'podcasting_talent_name' );
 	}
 
 	echo "<itunes:author>" . esc_html( $author ) . "</itunes:author>\n";
@@ -148,12 +148,8 @@ function podcasting_feed_item() {
 		echo '<itunes:keywords>' . esc_html( $keywords ) . "</itunes:keywords>\n";
 	}
 
-	if ( has_excerpt() ) {
-		$excerpt = get_the_excerpt();
-	} else {
-		$excerpt = get_option( 'podcasting_summary' );
-	}
-	$excerpt = apply_filters( 'the_excerpt_rss', $excerpt );
+	// Summary fallback order: custom excerpt > auto-generated post excerpt > empty string.
+	$excerpt = apply_filters( 'the_excerpt_rss', get_the_excerpt() );
 
 	echo "<itunes:summary>" . esc_html( strip_tags( $excerpt ) ) . "</itunes:summary>\n";
 


### PR DESCRIPTION
This PR syncs D14334-code.

This adds consistency and control to podcast episode settings by defaulting to the podcast's post settings.

Changes include:

- episode author defaults to post author (with channel author fallback)
- episode summary defaults to custom excerpt (with auto-generated excerpt fallback)
- episode subtitle defaults to episode summary

**To test:**
* Setup `wpcomsh` on a .org installation following the instructions in the [`README`](https://github.com/Automattic/wpcomsh#development).
* Edit `composer.json` within `wpcomsh` to change the version number for `automattic/at-pressable-podcasting` from its existing value to `dev-sync/D14334`.
* `composer update`
* Enable podcasting if it isn't already by visiting Media Options in wp-admin and selecting a category. (Note: if you've managed podcasting from Calypso, you should use that instead).
* Create/publish a new podcast post with a custom excerpt, and some content other than the podcast audio file
* View the podcast feed (i.e. https://cainstestingpaid.wordpress.com/category/podcast/feed/)
* Within the <item> tag for the most recent podcast episode:
 * <itunes:author> should be the post author's display name
 * <itunes:summary> and <itunes:subtitle> should be the custom excerpt
* Return to the post, delete the custom excerpt, save
* View the podcast feed
* Within the <item> tag for the most recent podcast episode:
 * <itunes:summary> and <itunes:subtitle> should be the auto-generated excerpt from WordPress (first 55 words)
* Return to the post, delete the post content (except for the podcast audio), save
* View the podcast feed
* Within the <item> tag for the most recent podcast episode:
 * <itunes:summary> and <itunes:subtitle> should be empty