### PR TITLE
Sync D14418: Podcasting: if no "Summary" is set, default to empty…

### DIFF
--- a/podcasting/customize-feed.php
+++ b/podcasting/customize-feed.php
@@ -21,9 +21,18 @@ function podcasting_bloginfo_rss_name( $output ) {
 
 add_filter( 'wp_title_rss', 'podcasting_bloginfo_rss_name' );
 
+function podcasting_modify_default_feed_description( $value, $field ) {
+	if ( $field === 'description' ) {
+		return get_option( 'podcasting_summary', '' );
+	}
+	return $value;
+}
+
+add_filter( 'bloginfo_rss', 'podcasting_modify_default_feed_description', 10, 2 );
+
 function podcasting_feed_head() {
 	$subtitle = get_option( 'podcasting_subtitle' );
-	
+
 	if ( empty( $subtitle ) ) {
 		$subtitle = get_bloginfo( 'description' );
 	}
@@ -33,10 +42,6 @@ function podcasting_feed_head() {
 	}
 
 	$summary = get_option( 'podcasting_summary' );
-
-	if ( empty( $summary ) ) {
-		$summary = get_bloginfo( 'description' );
-	}
 
 	if ( ! empty( $summary ) ) {
 		echo '<itunes:summary>' . esc_html( strip_tags( $summary ) ) . "</itunes:summary>\n";


### PR DESCRIPTION
…  strings for feed `description` and `itunes:summary` tags

This PR syncs D14418-code.

Currently, if "Summary" is not set, the following tags get set to the site title in the RSS feed:

- `itunes:summary`
- `description` (this is actually always set to the site tagline!)

This is not clear from the UI, and not even really correct (imagine a site that has a blog as well as a podcast... the summary and description are not likely the site title).

Instead, if no "Summary" is set, let's default to empty strings for both of these.

**Testing instructions**
* Setup `wpcomsh` on a .org installation following the instructions in the [`README`](https://github.com/Automattic/wpcomsh#development).
* Edit `composer.json` within `wpcomsh` to change the version number for `automattic/at-pressable-podcasting` from its existing value to `dev-sync/D14418`.
* `composer update`
* Enable podcasting if it isn't already by visiting Media Options in wp-admin and selecting a category. (Note: if you've managed podcasting from Calypso, you should use that instead).
* _Do not_ set a summary
* Visit the podcast feed
* The `description` tag should be empty and `itunes:summary` should be omitted
* Return to podcast settings, set a summary, and save the settings
* Visit the podcast feed
* The `itunes:summary` and `description` tags are set to the podcast summary