### PR TITLE
Widget: switch to using wp_calculate_image_srcset

### DIFF
--- a/podcasting/widget.php
+++ b/podcasting/widget.php
@@ -37,7 +37,8 @@ class Podcast_Widget extends WP_Widget {
 		$podcast_subtitle  = get_option( 'podcasting_subtitle'  );
 		$podcast_summary   = get_option( 'podcasting_summary'   );
 		$podcast_copyright = get_option( 'podcasting_copyright' );
-		$podcast_image     = get_option( 'podcasting_image'     );
+		$podcast_image_url = Automattic_Podcasting::podcasting_get_image_url();
+		$podcast_image_id  = get_option( 'podcasting_image_id' , false );
 
 		if ( ! empty( $instance['itunes_feed_id'] ) ) {
 			$subscribe_url = 'http://www.itunes.com/podcast?id=' . urlencode( $instance['itunes_feed_id'] );
@@ -49,16 +50,20 @@ class Podcast_Widget extends WP_Widget {
 			echo '<h3 class="podcast_title">' . esc_html( $podcast_title ) . '</h3>';
 		}
 
-		if ( ! empty( $podcast_image ) ) {
-			$podcast_srcset = $podcast_image;
+		if ( ! empty( $podcast_image_url ) ) {
 			if ( function_exists( 'jetpack_photon_url' ) ) {
-				$podcast_image  = jetpack_photon_url( $podcast_image, array( 'fit' => '300,300' ), 'https' );
-				$podcast_srcset =
-					esc_url( jetpack_photon_url( $podcast_image, array( 'fit' => '150,150' ), 'https' ) ) . ', ' .
-					esc_url( jetpack_photon_url( $podcast_image, array( 'fit' => '300,300' ), 'https' ) ) . ' 2x, ' .
-					esc_url( jetpack_photon_url( $podcast_image, array( 'fit' => '450,450' ), 'https' ) ) . ' 3x';
+				$podcast_image_url = jetpack_photon_url( $podcast_image_url, array( 'fit' => '300,300' ), 'https' );
 			}
-			echo '<a href="' . $subscribe_url . '"><img src="' . esc_url( $podcast_image ) . '" srcset="' . $podcast_srcset . '" /></a>';
+			echo '<a href="' . $subscribe_url . '">';
+			echo '<img src="' . esc_url( $podcast_image_url ) . '"';
+			if ( $podcast_image_id && is_numeric( $podcast_image_id ) && wp_attachment_is_image( $podcast_image_id ) ) {
+				echo ' srcset="' . wp_calculate_image_srcset(
+					array( 300, 300 ),
+					$podcast_image_url,
+					wp_get_attachment_metadata( $podcast_image_id )
+				) . '"';
+			}
+			echo ' /></a>';
 		}
 
 		if ( ! empty( $podcast_subtitle ) ) {


### PR DESCRIPTION
This PR switches to using `wp_calculate_image_srcset` for the calculation of the `srcset` in the podcasting widget. Because that function only works with attachments, the widget only includes a `srcset` when the option `podcasting_image_id` is set. This will be the case if you set the image via Calypso. If you set the image via wp-admin, which just has a bare URL field, no attachment is set, and therefore `srcset` is omitted.

**To test:**
* Setup `wpcomsh` on a .org installation following the instructions in the [`README`](https://github.com/Automattic/wpcomsh#development).
* Edit `composer.json` within `wpcomsh` to change the version number for `automattic/at-pressable-podcasting` from `1.0.0` to `dev-update/use-wp-calculate-image-srcset`.
* `composer update`
* Verify that when you set an image for your podcast, that the image appears in the podcasting widget, regardless of whether the image was set in Calypso or via wp-admin.
* Verify that, if the image was set in Calypso, the `srcset` attribute appears (otherwise, it will not).