### PR TITLE
Fix iTunes URL and avoid notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/at-pressable-podcasting",
-  "version": "v1.2.5",
+  "version": "v1.2.6",
   "autoload": {
     "files": [ "podcasting.php" ]
   }

--- a/podcasting/widget.php
+++ b/podcasting/widget.php
@@ -29,7 +29,8 @@ class Podcast_Widget extends WP_Widget {
 
 		echo $args['before_widget'];
 
-		$title = apply_filters( 'widget_title', $instance['title'] );
+		$title = isset( $instance['title'] ) ? $instance['title'] : '';
+		$title = apply_filters( 'widget_title', $title );
 		if ( ! empty( $title ) )
 			echo $args['before_title'] . $title . $args['after_title'];
 
@@ -40,7 +41,7 @@ class Podcast_Widget extends WP_Widget {
 		$podcast_image     = get_option( 'podcasting_image'     );
 
 		if ( ! empty( $instance['itunes_feed_id'] ) ) {
-			$subscribe_url = 'http://www.itunes.com/podcast?id=' . urlencode( $instance['itunes_feed_id'] );
+			$subscribe_url = 'https://podcasts.apple.com/podcast/id' . urlencode( $instance['itunes_feed_id'] );
 		} else {
 			$subscribe_url = 'itpc://' . str_replace( 'http://', '', site_url( '/category/' . esc_attr( $podcast_category->slug ) . '/feed/', 'http' ) );
 		}


### PR DESCRIPTION
Related to this bug report https://github.com/Automattic/jpop-issues/issues/3913

This PR:
* Fixes Apple Podcasts subscribe URL, as already fixed and deployed in D36994-code
* Avoids an error notice when the title is empty, as done here (not deployed yet): D53248-code

## Test plan

See D36994-code