### PR TITLE
Sync r225657

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/at-pressable-podcasting",
-  "version": "v1.2.6",
+  "version": "v1.2.7",
   "autoload": {
     "files": [ "podcasting.php" ]
   }

--- a/podcasting/customize-feed.php
+++ b/podcasting/customize-feed.php
@@ -2,6 +2,7 @@
 
 function podcasting_xmlns() {
 	echo "\n\t" . 'xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"' . "\n";
+	echo "\t" . 'xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0"' . "\n";
 }
 
 add_action( 'rss2_ns', 'podcasting_xmlns' );
@@ -32,7 +33,6 @@ add_filter( 'bloginfo_rss', 'podcasting_modify_default_feed_description', 10, 2 
 
 function podcasting_feed_head() {
 	$subtitle = get_option( 'podcasting_subtitle' );
-
 	if ( empty( $subtitle ) ) {
 		$subtitle = get_bloginfo( 'description' );
 	}
@@ -42,73 +42,56 @@ function podcasting_feed_head() {
 	}
 
 	$summary = get_option( 'podcasting_summary' );
-
 	if ( ! empty( $summary ) ) {
 		echo '<itunes:summary>' . esc_html( strip_tags( $summary ) ) . "</itunes:summary>\n";
+		echo '<googleplay:description>' . esc_html( strip_tags( $summary ) ) . "</googleplay:description>\n";
 	}
 
 	$author = get_option( 'podcasting_talent_name' );
-
 	if ( ! empty( $author ) ) {
 		echo '<itunes:author>' . esc_html( strip_tags( $author ) ) . "</itunes:author>\n";
+		echo '<googleplay:author>' . esc_html( strip_tags( $author ) ) . "</googleplay:author>\n";
 	}
 
 	$email = get_option( 'podcasting_email' );
-
 	if ( ! empty( $email ) ) {
 		echo '<itunes:owner>';
-		echo '<itunes:email>' . esc_html( strip_tags ( $email ) ) . "</itunes:email>\n";
+		echo '<itunes:email>' . esc_html( strip_tags( $email ) ) . "</itunes:email>\n";
 		echo '</itunes:owner>';
+		echo '<googleplay:owner>' . esc_html( strip_tags( $email ) ) . "</googleplay:owner>\n";
+		echo '<googleplay:email>' . esc_html( strip_tags( $email ) ) . "</googleplay:email>\n";
 	}
 
 	$copyright = get_option( 'podcasting_copyright' );
-
 	if ( !empty( $copyright ) ) {
 		echo '<copyright>' . esc_html( strip_tags( $copyright ) ) . "</copyright>\n";
 	}
 
-	$explicit = get_option( 'podcasting_explicit' );
-
-	echo '<itunes:explicit>';
-
-	if ( empty( $explicit ) ) {
-		echo 'no';
-	} else {
-		echo esc_html( $explicit );
-	}
-
-	echo "</itunes:explicit>\n";
+	$explicit = get_option( 'podcasting_explicit', 'no' );
+	echo '<itunes:explicit>' . esc_html( $explicit ) . "</itunes:explicit>\n";
+	echo '<googleplay:explicit>' . esc_html( $explicit ) . "</googleplay:explicit>\n";
 
 	$image = Automattic_Podcasting::podcasting_get_image_url();
-
 	if ( ! empty( $image ) ) {
 		if ( function_exists( 'jetpack_photon_url' ) ) {
 			$image = jetpack_photon_url( $image, array( 'fit' => '3000,3000' ), 'https' );
 		}
 
 		echo "<itunes:image href='" . esc_url( $image ) . "' />\n";
-	}
-
-	$keywords = get_option( 'podcasting_keywords' );
-
-	if ( ! empty( $keywords ) ) {
-		echo '<itunes:keywords>' . esc_html( $keywords ) . "</itunes:keywords>\n";
+		echo "<googleplay:image href='" . esc_url( $image ) . "' />\n";
 	}
 
 	$category_1 = podcasting_generate_category( 'podcasting_category_1' );
-
 	if ( ! empty( $category_1 ) ) {
 		echo $category_1;
 	}
 
 	$category_2 = podcasting_generate_category( 'podcasting_category_2' );
-
 	if ( ! empty( $category_2 ) ) {
 		echo $category_2;
 	}
 
 	$category_3 = podcasting_generate_category( 'podcasting_category_3' );
-
 	if ( ! empty( $category_3 ) ) {
 		echo $category_3;
 	}
@@ -119,26 +102,16 @@ add_action( 'rss2_head', 'podcasting_feed_head' );
 function podcasting_feed_item() {
 	global $post;
 
-	$post_meta = get_post_meta( $post->ID, 'podcast_episode', true );
-
 	$author = get_the_author();
 	if ( empty( $author ) ) {
 		$author = get_option( 'podcasting_talent_name' );
 	}
+	echo '<itunes:author>' . esc_html( strip_tags( $author ) ) . "</itunes:author>\n";
+	echo '<googleplay:author>' . esc_html( strip_tags( $author ) ) . "</googleplay:author>\n";
 
-	echo "<itunes:author>" . esc_html( $author ) . "</itunes:author>\n";
-
-	$explicit = get_option( 'podcasting_explicit' );
-
-	echo "<itunes:explicit>";
-
-	if ( empty( $explicit ) ) {
-		echo 'no';
-	} else {
-		echo esc_html( $explicit );
-	}
-
-	echo "</itunes:explicit>\n";
+	$explicit = get_option( 'podcasting_explicit', 'no' );
+	echo '<itunes:explicit>' . esc_html( $explicit ) . "</itunes:explicit>\n";
+	echo '<googleplay:explicit>' . esc_html( $explicit ) . "</googleplay:explicit>\n";
 
 	if ( has_post_thumbnail( $post->ID ) ) {
 		$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'post-thumbnail' );
@@ -147,42 +120,40 @@ function podcasting_feed_item() {
 				$image = $image[0];
 			}
 			echo "<itunes:image href='" . esc_url( $image ) . "' />\n";
+			echo "<googleplay:image href='" . esc_url( $image ) . "' />\n";
 		}
-	}
-
-	$keywords = '';
-	if ( ! empty( $keywords ) ) {
-		echo '<itunes:keywords>' . esc_html( $keywords ) . "</itunes:keywords>\n";
 	}
 
 	// Summary fallback order: custom excerpt > auto-generated post excerpt > empty string.
 	$excerpt = apply_filters( 'the_excerpt_rss', get_the_excerpt() );
+	echo '<itunes:summary>' . esc_html( strip_tags( $excerpt ) ) . "</itunes:summary>\n";
+	echo '<googleplay:description>' . esc_html( strip_tags( $excerpt ) ) . "</googleplay:description>\n";
 
-	echo "<itunes:summary>" . esc_html( strip_tags( $excerpt ) ) . "</itunes:summary>\n";
-
-	$subtitle = wp_trim_words( $excerpt, 10, '&#8230;' );
-
-	echo "<itunes:subtitle>" . esc_html( $subtitle ) . "</itunes:subtitle>\n";
-
-	if ( ! empty( $post_meta['enclosure'] ) ) {
-		echo "<enclosure url='" . esc_url( $post_meta['enclosure']['url'] ) . "' length='" . esc_html( $post_meta['enclosure']['length'] ) . "' type='" . esc_html( $post_meta['enclosure']['mime'] ) . "' />\n";
-	}
-
-	// TODO <itunes:duration>7:10</itunes:duration>; iTunes seems to figure this out on it's own. Would be nice to have in the future
+	// Let podcast players trim the excerpt as needed for the subtitle.
+	echo '<itunes:subtitle>' . esc_html( strip_tags( $excerpt ) ) . "</itunes:subtitle>\n";
 }
 
 add_action( 'rss2_item', 'podcasting_feed_item' );
 
 function podcasting_rss_enclosure( $enclosure ) {
-	global $post;
+	preg_match( '/url="([^"]*)"/i', $enclosure, $result );
 
-	$post_meta = get_post_meta( $post->ID, 'podcast_episode', true );
+	if ( $result ) {
+		$attachment_id = attachment_url_to_postid( $result[1] );
 
-	if ( empty( $post_meta['enclosure'] ) ) {
-		return $enclosure;
+		if ( 0 === $attachment_id ) {
+			return $enclosure;
+		}
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		$duration = absint( $metadata['length'] );
+
+		if ( 0 !== $duration ) {
+			return $enclosure . '<itunes:duration>' . $duration . "</itunes:duration>\n";
+		}
 	}
 
-	return '';
+	return $enclosure;
 }
 
 add_filter( 'rss_enclosure', 'podcasting_rss_enclosure' );

--- a/podcasting/settings.php
+++ b/podcasting/settings.php
@@ -333,62 +333,59 @@ function podcasting_settings_media_screen() {
 }
 add_action( 'load-options-media.php', 'podcasting_settings_media_screen' );
 
-
-
-
 function podcasting_settings_scripts() {
-?>
-<script>
-jQuery( document ).ready( function( $ ) {
+	?>
+	<script>
+	jQuery( document ).ready( function( $ ) {
 
-	var isPodcastingImage = false;
+		var isPodcastingImage = false;
 
-	$( '#podcasting-image-button' ).click( function( e ) {
-		isPodcastingImage = true;
-		tb_show( '', 'media-upload.php?type=image&post_id=0&TB_iframe=true' );
-		e.preventDefault();
-	} );
+		$( '#podcasting-image-button' ).click( function( e ) {
+			isPodcastingImage = true;
+			tb_show( '', 'media-upload.php?type=image&post_id=0&TB_iframe=true' );
+			e.preventDefault();
+		} );
 
-	window.original_send_to_editor = window.send_to_editor;
+		window.original_send_to_editor = window.send_to_editor;
 
-	window.send_to_editor = function( html ) {
-		var $html  = $( html );
-			source = '';
+		window.send_to_editor = function( html ) {
+			var $html  = $( html );
+				source = '';
 
-		if ( isPodcastingImage ) {
-			if ( $html.is( 'img' ) )
-				source = $html.attr( 'src' );
-			else if ( $html.is( 'a' ) )
-				source = $html.find( 'img' ).attr( 'src' );
+			if ( isPodcastingImage ) {
+				if ( $html.is( 'img' ) )
+					source = $html.attr( 'src' );
+				else if ( $html.is( 'a' ) )
+					source = $html.find( 'img' ).attr( 'src' );
 
-			$( '#podcasting-image-url' ).val( source );
-			$( '#podcasting-image-preview' ).attr( 'src', source ).show();
-			$( '#podcasting-image' ).show();
-			isPodcastingImage = false;
-			tb_remove();
-		} else {
-			window.original_send_to_editor( html );
+				$( '#podcasting-image-url' ).val( source );
+				$( '#podcasting-image-preview' ).attr( 'src', source ).show();
+				$( '#podcasting-image' ).show();
+				isPodcastingImage = false;
+				tb_remove();
+			} else {
+				window.original_send_to_editor( html );
+			}
 		}
-	}
 
-} );
-</script>
-<style>
-#podcasting-image {
-	display: none;
-	width: 200px;
-	height: 200px;
-	text-align: center;
-}
-#podcasting-image.podcasting-image-set {
-	display: block;
-}
-#podcasting-image-preview {
-	max-width: 100%;
-	max-height: 100%;
-}
-</style>
-<?php
+	} );
+	</script>
+	<style>
+	#podcasting-image {
+		display: none;
+		width: 200px;
+		height: 200px;
+		text-align: center;
+	}
+	#podcasting-image.podcasting-image-set {
+		display: block;
+	}
+	#podcasting-image-preview {
+		max-width: 100%;
+		max-height: 100%;
+	}
+	</style>
+	<?php
 }
 
 function podcasting_settings_admin_enqueue_scripts() {

--- a/podcasting/widget.php
+++ b/podcasting/widget.php
@@ -12,7 +12,7 @@ class Podcast_Widget extends WP_Widget {
 	function __construct() {
 		parent::__construct( 'podcast', __( 'Podcast' ), array(
 			'classname'   => 'widget-podcast',
-			'description' => esc_html__( 'Display information about your Podcast and an allow visitors to subscribe via iTunes' ),
+			'description' => esc_html__( 'Display information about your Podcast and allow visitors to follow via iTunes' ),
 		) );
 	}
 
@@ -31,20 +31,16 @@ class Podcast_Widget extends WP_Widget {
 
 		$title = isset( $instance['title'] ) ? $instance['title'] : '';
 		$title = apply_filters( 'widget_title', $title );
-		if ( ! empty( $title ) )
+
+		if ( ! empty( $title ) ) {
 			echo $args['before_title'] . $title . $args['after_title'];
+		}
 
 		$podcast_title     = get_option( 'podcasting_title'     );
 		$podcast_subtitle  = get_option( 'podcasting_subtitle'  );
 		$podcast_summary   = get_option( 'podcasting_summary'   );
 		$podcast_copyright = get_option( 'podcasting_copyright' );
 		$podcast_image     = get_option( 'podcasting_image'     );
-
-		if ( ! empty( $instance['itunes_feed_id'] ) ) {
-			$subscribe_url = 'https://podcasts.apple.com/podcast/id' . urlencode( $instance['itunes_feed_id'] );
-		} else {
-			$subscribe_url = 'itpc://' . str_replace( 'http://', '', site_url( '/category/' . esc_attr( $podcast_category->slug ) . '/feed/', 'http' ) );
-		}
 
 		if ( ! empty( $podcast_title ) ) {
 			echo '<h3 class="podcast_title">' . esc_html( $podcast_title ) . '</h3>';
@@ -59,7 +55,7 @@ class Podcast_Widget extends WP_Widget {
 					esc_url( jetpack_photon_url( $podcast_image, array( 'fit' => '300,300' ), 'https' ) ) . ' 2x, ' .
 					esc_url( jetpack_photon_url( $podcast_image, array( 'fit' => '450,450' ), 'https' ) ) . ' 3x';
 			}
-			echo '<a href="' . $subscribe_url . '"><img src="' . esc_url( $podcast_image ) . '" srcset="' . $podcast_srcset . '" /></a>';
+			echo '<p class="podcast_image_wrapper"><img class="podcast_image" src="' . esc_url( $podcast_image ) . '" srcset="' . $podcast_srcset . '" /></p>';
 		}
 
 		if ( ! empty( $podcast_subtitle ) ) {
@@ -73,28 +69,49 @@ class Podcast_Widget extends WP_Widget {
 		if ( ! empty( $podcast_copyright ) ) {
 			echo '<p class="podcast_copyright">' . esc_html( $podcast_copyright ) . '</p>';
 		}
-		
+
+		echo '<ul class="podcast_subscribe-links">';
+
 		// TODO use a fancy image?
-		echo '<p><a href="' . $subscribe_url . '">Subscribe via iTunes</a></p>';
+		if ( ! empty( $instance['itunes_feed_id'] ) ) {
+			$itunes_subscribe_url = 'https://podcasts.apple.com/podcast/id' . urlencode( $instance['itunes_feed_id'] );
+			echo '<li><a href="' . esc_url( $itunes_subscribe_url ) . '">' . esc_html__( 'Listen on Apple Podcasts' ) . '</a></li>';
+		}
+
+		if ( ! empty( $instance['spotify_feed_id'] ) ) {
+			$spotify_subscribe_url = 'https://open.spotify.com/show/' . urlencode( $instance['spotify_feed_id'] );
+			echo '<li><a href="' . esc_url( $spotify_subscribe_url ) . '">' . esc_html__( 'Listen on Spotify' ) . '</a></li>';
+		}
+
+		echo '<li><a href="' . esc_url( get_category_feed_link( Automattic_Podcasting::podcasting_get_podcasting_category_id() ) ) . '">' . esc_html__( 'Podcast RSS Feed' ) . '</a></li>';
+
+		echo '</ul>';
 
 		echo $args['after_widget'];
 		do_action( 'jetpack_stats_extra', 'widget_view', 'podcasting' );
 	}
 
 	function form( $instance ) {
-		$title          = isset( $instance['title'] )          ? $instance['title']          : '';
-		$itunes_feed_id = isset( $instance['itunes_feed_id'] ) ? $instance['itunes_feed_id'] : '';
+		$title           = isset( $instance['title'] ) ? $instance['title'] : '';
+		$itunes_feed_id  = isset( $instance['itunes_feed_id'] ) ? $instance['itunes_feed_id'] : '';
+		$spotify_feed_id = isset( $instance['spotify_feed_id'] ) ? $instance['spotify_feed_id'] : '';
 		?>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>">
-				<?php esc_html_e( 'Title' ); ?> <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
+				<?php esc_html_e( 'Title' ); ?> <input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
 			</label>
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'itunes_feed_id' ); ?>">
-				<?php esc_html_e( 'iTunes Feed ID' ); ?> (<a href="http://www.apple.com/itunes/podcasts/specs.html#submitting">?</a>) <input class="widefat" id="<?php echo $this->get_field_id( 'itunes_feed_id' ); ?>" name="<?php echo $this->get_field_name( 'itunes_feed_id' ); ?>" type="text" value="<?php echo esc_attr( $itunes_feed_id ); ?>" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'itunes_feed_id' ) ); ?>">
+				<?php esc_html_e( 'Apple Podcasts Feed ID' ); ?> (<a href="https://wordpress.com/support/audio/podcasting/#submit-to-apple-podcasts">?</a>) <input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'itunes_feed_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'itunes_feed_id' ) ); ?>" type="text" value="<?php echo esc_attr( $itunes_feed_id ); ?>" />
+			</label>
+		</p>
+
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'spotify_feed_id' ) ); ?>">
+				<?php esc_html_e( 'Spotify Feed ID' ); ?> (<a href="https://wordpress.com/support/audio/podcasting/#submit-to-spotify">?</a>) <input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'spotify_feed_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'spotify_feed_id' ) ); ?>" type="text" value="<?php echo esc_attr( $spotify_feed_id ); ?>" />
 			</label>
 		</p>
 
@@ -102,9 +119,14 @@ class Podcast_Widget extends WP_Widget {
 	}
 
 	function update( $new_instance, $old_instance ) {
-		$instance                   = array();
-		$instance['title']          = isset( $new_instance['title'] )          ? wp_kses( $new_instance['title'], array() ) : '';
-		$instance['itunes_feed_id'] = isset( $new_instance['itunes_feed_id'] ) ? $new_instance['itunes_feed_id']            : '';
+		$instance          = array();
+		$instance['title'] = isset( $new_instance['title'] ) ? wp_kses( $new_instance['title'], array() ) : '';
+
+		// Strip Apple URL and sanitize ID
+		$instance['itunes_feed_id']  = isset( $new_instance['itunes_feed_id'] ) ? sanitize_text_field( str_replace( 'https://podcasts.apple.com/podcast/id', '', $new_instance['itunes_feed_id'] ) ) : '';
+
+		// Strip Spotify URL and sanitize ID
+		$instance['spotify_feed_id'] = isset( $new_instance['spotify_feed_id'] ) ? sanitize_text_field( str_replace( 'https://open.spotify.com/show/', '', $new_instance['spotify_feed_id'] ) ) : '';
 
 		return $instance;
 	}


### PR DESCRIPTION
On Team 51 we work on Matt's distributed.blog (wpcom business/atomic) and we noticed that the podcasting feature was missing a few things when compared to what's currently available in the wpcom version.

I compared the latest revision on SVN to what's on master here and then copied the relevant updates.

Pinging y'all for a review since you were the most recent contributors to this repo. 

Thank you!

**Testing instructions**

* Setup `wpcomsh` on a .org installation following the instructions in the README.
* Edit `composer.json` within `wpcomsh` to change the version number for `automattic/at-pressable-podcasting` from its existing value to `sync/r225657`.
* `composer update`
* Enable podcasting if it isn't already by visiting Media Options in wp-admin and selecting a category. (Note: if you've managed podcasting from Calypso, you should use that instead).
* Verify that options in Media Options work.
* Verify that the feed works.

