### PR TITLE
Use the full image for podcast episode images

### DIFF
--- a/podcasting/customize-feed.php
+++ b/podcasting/customize-feed.php
@@ -104,11 +104,17 @@ function podcasting_feed_item() {
 	echo '<googleplay:explicit>' . esc_html( $explicit ) . "</googleplay:explicit>\n";
 
 	if ( has_post_thumbnail( $post->ID ) ) {
-		$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'post-thumbnail' );
+		$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
 		if ( ! empty( $image ) ) {
 			if ( is_array( $image ) ) {
 				$image = $image[0];
 			}
+
+			if ( function_exists( 'jetpack_photon_url' ) ) {
+				// The acceptable size ranges from 1400px square to 3000px
+				$image = jetpack_photon_url( $image, array( 'fit' => '3000,3000' ), 'https' );
+			}
+
 			echo "<itunes:image href='" . esc_url( $image ) . "' />\n";
 			echo "<googleplay:image href='" . esc_url( $image ) . "' />\n";
 		}


### PR DESCRIPTION
Apple require that podcast images are at least 1400x1400px. wpcom doesn't set a specific set of thumbnail sizes, and the highest explicit thumbnail size is 1024x1024px. This means we have to use the full image, and then pass it through photon to ensure we don't exceed the limit of 3000x3000px.

This syncs b4668c555 from GHE, it doesn't sync any other changes.