### PR TITLE
Provide a fallback if metadata is incomplete

### DIFF
--- a/podcasting/customize-feed.php
+++ b/podcasting/customize-feed.php
@@ -142,7 +142,7 @@ function podcasting_rss_enclosure( $enclosure ) {
 		}
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
-		$duration = absint( $metadata['length'] );
+		$duration = absint( $metadata['length'] ?? 0 );
 
 		if ( 0 !== $duration ) {
 			return $enclosure . '<itunes:duration>' . $duration . "</itunes:duration>\n";


### PR DESCRIPTION
This PR addresses the following warnings:
```
PHP Warning: Trying to access array offset on false in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763750826.gc87d55a/vendor/automattic/at-pressable-podcasting/podcasting/customize-feed.php on line 145
```
```
PHP Warning: Undefined array key "length" in /wordpress/plugins/wpcomsh/8.1.0-alpha+rolling.1763750826.gc87d55a/vendor/automattic/at-pressable-podcasting/podcasting/customize-feed.php on line 145
```

With this branch, whether `$metadata` is falsy or missing a 'length' key, it'll fall back to `0` and no longer print the irrelevant `<itunes:duration>` tag.