### PR TITLE
Prepare v2.0.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This repo is a Wordpress.com plugin that replicates wpcom podcasting behavior.
 It is taken from wpcom codebase and refactored to work with any jetpack site.
 
+## To release
+1. Bump `composer.json` to have the correct version.
+2. Create a new GitHub release. Be sure to mention what changed in the release notes.
+
 ## License
 
 Pressable Podcasting is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt).

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,5 @@
   "name": "automattic/at-pressable-podcasting",
   "license": "GPL-2.0-or-later",
   "type": "wordpress-plugin",
-  "version": "v2.0.4"
+  "version": "v2.0.5"
 }


### PR DESCRIPTION
This bumps the version in the `composer.json` and also adds some instructions on how to release.