### PR TITLE
Tracks: Add guard to ensure $post is a WP_Post

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,5 @@
   "name": "automattic/at-pressable-podcasting",
   "license": "GPL-2.0-or-later",
   "type": "wordpress-plugin",
-  "version": "v2.0.6"
+  "version": "v2.0.7"
 }

--- a/podcasting/tracks.php
+++ b/podcasting/tracks.php
@@ -25,6 +25,9 @@ class Automattic_Podcasting_Tracks {
 	}
 
 	public function record_episode_published( $post_id, $post, $update, $post_before ) {
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
 		if ( 'publish' !== $post->post_status ) {
 			return;
 		}


### PR DESCRIPTION
Prevent warning when `$post` is not actually a `WP_Post`.

Also bump version to 2.0.7.

See: p1777059991367929-slack-C05Q5HSS013