### PR TITLE
Release v2.0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,5 @@
   "name": "automattic/at-pressable-podcasting",
   "license": "GPL-2.0-or-later",
   "type": "wordpress-plugin",
-  "version": "v2.0.7"
+  "version": "v2.0.8"
 }


### PR DESCRIPTION
## Summary
- Bumps `composer.json` to `v2.0.8` so Atomic can pull in the latest fix.

## Changes since v2.0.7
- Gate legacy plugin behind `jetpack_podcast_untangle` filter (#29)