### PR TITLE
Sync podcasting_category_id via Jetpack Sync options whitelist

### DIFF
--- a/podcasting.php
+++ b/podcasting.php
@@ -12,6 +12,15 @@ function automattic_podcasting_init() {
 
 class Automattic_Podcasting {
 	function __construct() {
+		// Replicate `podcasting_category_id` to WordPress.com via Jetpack Sync.
+		// The wpcom-side Activity Log gate (`Activity_Podcast::post_is_in_podcast_category`)
+		// calls `get_option( 'podcasting_category_id' )` on the replicastore;
+		// without the option in the sync whitelist, the call returns nothing on
+		// Atomic and Jetpack-connected sites and no podcast publishes match.
+		// Registered before the untangle bail so the option syncs regardless of
+		// which podcast layer owns the UI on this site.
+		add_filter( 'jetpack_sync_options_whitelist', array( __CLASS__, 'add_sync_options_whitelist' ) );
+
 		/**
 		 * Stand down on sites where the new automattic/jetpack-podcast
 		 * package owns RSS customization, settings, Tracks, and the
@@ -46,6 +55,18 @@ class Automattic_Podcasting {
 
 			require_once plugin_dir_path( __FILE__ ) . 'podcasting/widget.php';
 		}
+	}
+
+	/**
+	 * Add `podcasting_category_id` to Jetpack Sync's options whitelist so the
+	 * setting replicates from Atomic / Jetpack-connected sites to WordPress.com.
+	 *
+	 * @param array $options Option names allowed to sync.
+	 * @return array Updated option names.
+	 */
+	public static function add_sync_options_whitelist( $options ) {
+		$options[] = 'podcasting_category_id';
+		return array_values( array_unique( $options ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Add `podcasting_category_id` to Jetpack Sync's options whitelist so the option replicates from Atomic and Jetpack-connected sites to WordPress.com.

## Why

The Activity Log gate added in 216818-ghe-Automattic/wpcom calls `get_option( 'podcasting_category_id' )` server-side on WordPress.com to decide whether a published post is a podcast episode. The option lives on the remote site, so on Atomic and Jetpack-connected sites it has to flow through Jetpack Sync to reach the replicastore. It isn't in the default whitelist, so the call returns nothing on non-Simple sites and the gate matches nothing.

fgiannar flagged this on the wpcom review:

> For Jetpack and Atomic sites, `podcasting_category_id` is set on the remote site. This option is not currently in Sync's options whitelist, so it won't be present in the WPcom replicastore. `get_option('podcasting_category_id')` will return nothing on the WPcom side for non-Simple sites, and no podcast publishes will ever match.

The filter registers in the constructor before the `jetpack_podcast_untangle` bail so the option syncs whether this legacy plugin or the new [`automattic/jetpack-podcast`](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/podcast) package owns the UI. Double registration is safe since the package's [`Settings::register()`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/podcast/src/class-settings.php) dedupes with `array_values( array_unique( $options ) )`.

## Testing instructions

On an Atomic or Jetpack-connected site:

1. Set the option locally:
   ```
   wp option update podcasting_category_id 5
   ```
2. Run a Sync flush:
   ```
   wp jetpack-sync start --modules=options
   ```
3. On WordPress.com against the same blog, confirm the option landed:
   ```
   wp --url=<blog-url> option get podcasting_category_id
   ```
   Returns `5` after this change, nothing before it.

Then publish a post in that category and confirm `podcast__show_launched` and `podcast__episode_published` Activity Log entries fire on WordPress.com.
